### PR TITLE
Revert Gradle API changes.

### DIFF
--- a/activity-container/build.gradle
+++ b/activity-container/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 }

--- a/android-services/build.gradle
+++ b/android-services/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version='1.1-SNAPSHOT'
+    version='1.2-SNAPSHOT'
     group='com.github.InkApplications.DriveChain'
 }
 

--- a/fresco-bridge/build.gradle
+++ b/fresco-bridge/build.gradle
@@ -1,8 +1,8 @@
 
 dependencies {
-    api 'com.facebook.fresco:fresco:1.5.0'
-    api "com.facebook.fresco:imagepipeline-okhttp3:1.5.0"
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile 'com.facebook.fresco:fresco:1.5.0'
+    compile "com.facebook.fresco:imagepipeline-okhttp3:1.5.0"
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
-    api project(":lifecycle")
+    compile project(":lifecycle")
 }

--- a/joda_bridge/build.gradle
+++ b/joda_bridge/build.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
-    api 'net.danlew:android.joda:2.9.9.2'
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile 'net.danlew:android.joda:2.9.9.2'
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
-    api project(":lifecycle")
+    compile project(":lifecycle")
 }

--- a/leakcanary-bridge-noop/build.gradle
+++ b/leakcanary-bridge-noop/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 }

--- a/leakcanary-bridge/build.gradle
+++ b/leakcanary-bridge/build.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
-    api 'com.squareup.leakcanary:leakcanary-android:1.5.4'
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     compile project(":lifecycle")
 }

--- a/lifecycle/build.gradle
+++ b/lifecycle/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 }

--- a/okhttp-bridge/build.gradle
+++ b/okhttp-bridge/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-    api 'com.squareup.okhttp3:okhttp:3.9.1'
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile 'com.squareup.okhttp3:okhttp:3.9.1'
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 }

--- a/stetho-bridge-noop/build.gradle
+++ b/stetho-bridge-noop/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
-    api "com.google.dagger:dagger:$daggerVersion"
+    compile "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 }


### PR DESCRIPTION
Changing things to the `api` keyword has broken transitive dependencies.
revert the code back to `compile` for now.